### PR TITLE
Changed the default date_format (Removed leading 0 on 1-9 days)

### DIFF
--- a/TweetPHP.php
+++ b/TweetPHP.php
@@ -54,7 +54,7 @@
           'ignore_retweets'       => true, // Ignore retweets
           'twitter_style_dates'   => false, // Use twitter style dates e.g. 2 hours ago
           'twitter_date_text'     => array('seconds', 'minutes', 'about', 'hour', 'ago'),
-          'date_format'           => '%I:%M %p %b %d%O', // The defult date format e.g. 12:08 PM Jun 12th. See: http://php.net/manual/en/function.strftime.php
+          'date_format'           => '%I:%M %p %b %e%O', // The defult date format e.g. 12:08 PM Jun 12th. See: http://php.net/manual/en/function.strftime.php
           'date_lang'             => null, // Language for date e.g. 'fr_FR'. See: http://php.net/manual/en/function.setlocale.php
           'format'                => 'html', // Can be 'html' or 'array'
           'twitter_wrap_open'     => '<h2>Latest tweets</h2><ul id="twitter">',


### PR DESCRIPTION
If the date is between the 1st and 9th of the month the date number has a leading zero, which looks a little weird.

eg: 07:15 PM Nov 02nd

I know that I can change this in the date_format settings, but I think the day should be %e instead of %d by default.

(Not sure why it's suggesting that I made a change on line 278 (I didn't)).
